### PR TITLE
nginx用のECRを追加

### DIFF
--- a/envs/prod/app/recordable/ecr.tf
+++ b/envs/prod/app/recordable/ecr.tf
@@ -5,3 +5,26 @@ resource "aws_ecr_repository" "nginx" {
     Name = "infra-prod-recordable-nginx"
   }
 }
+
+resource "aws_ecr_lifecycle_policy" "nginx" {
+  policy = jsonencode(
+    {
+      "rules" : [
+        {
+          "rulePriority" : 1,
+          "description" : "Hold only 10 images, expire all others",
+          "selection" : {
+            "tagStatus" : "any",
+            "countType" : "imageCountMoreThan",
+            "countNumber" : 10
+          },
+          "action" : {
+            "type" : "expire"
+          }
+        }
+      ]
+    }
+  )
+
+  repository = aws_ecr_repository.nginx.name
+}

--- a/envs/prod/app/recordable/ecr.tf
+++ b/envs/prod/app/recordable/ecr.tf
@@ -1,0 +1,7 @@
+resource "aws_ecr_repository" "nginx" {
+  name = "infra-prod-recordable-nginx"
+
+  tags = {
+    Name = "infra-prod-recordable-nginx"
+  }
+}

--- a/envs/prod/provider.tf
+++ b/envs/prod/provider.tf
@@ -3,7 +3,7 @@ provider "aws" {
 
   default_tags {
     tags = {
-      Env = "prod"
+      Env    = "prod"
       System = "infra"
     }
   }


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
nginx用のECRを追加

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
AWS Fargate で Docker のコンテナを動かすためには、事前にその Docker イメージをコンテナレジストリに登録しておく必要があるため。

## やったこと
・やったことを簡単にまとめる
nginxのecr repositoryとecrのlife cycle poricyを追加

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
**image_tag_mutability**

Docker イメージとしてのタグの変更が可能かどうかの設定 です。
デフォルトは MUTABLE(変更可能) 



**tags_all**

terraformの独自属性。

設定されるもの
・provider ブロックで指定したデフォルトのタグ
・リソース個別に指定したタグ (tags の内容) 



**known after apply**

実際に AWS リソースが作成されて初めて 値が決まる属性



`terraform state list`

tfstate で管理されているリソースの一覧を確認
tfstate : Terraformが管理しているリソースの現在の状態を表すファイル



`terraform state show`

tfstate 上でどのような属性や値を 持っているかを確認

policy 
どのようなルールでイメージを削除するかを追加。
最新の 10 個までイメージを残し、それより古いものは自動削除される
jsonencode functionで記述内容を返すようにしている


## 今後の変更計画



## 備考
・その他伝えたいこと