### PR TITLE
PHPのECRを追加

### DIFF
--- a/envs/prod/app/recordable/ecr.tf
+++ b/envs/prod/app/recordable/ecr.tf
@@ -1,11 +1,11 @@
 module "nginx" {
   source = "../../../../modules/ecr"
 
-  name = "infra-prod-recordable-nginx"
+  name = "${local.name_prefix}-${local.service_name}-nginx"
 }
 
 module "php" {
   source = "../../../../modules/ecr"
 
-  name = "infra-prod-recordable-php"
+  name = "${local.name_prefix}-${local.service_name}-php"
 }

--- a/envs/prod/app/recordable/ecr.tf
+++ b/envs/prod/app/recordable/ecr.tf
@@ -1,30 +1,5 @@
-resource "aws_ecr_repository" "nginx" {
+module "nginx" {
+  source = "../../../../modules/ecr"
+
   name = "infra-prod-recordable-nginx"
-
-  tags = {
-    Name = "infra-prod-recordable-nginx"
-  }
-}
-
-resource "aws_ecr_lifecycle_policy" "nginx" {
-  policy = jsonencode(
-    {
-      "rules" : [
-        {
-          "rulePriority" : 1,
-          "description" : "Hold only 10 images, expire all others",
-          "selection" : {
-            "tagStatus" : "any",
-            "countType" : "imageCountMoreThan",
-            "countNumber" : 10
-          },
-          "action" : {
-            "type" : "expire"
-          }
-        }
-      ]
-    }
-  )
-
-  repository = aws_ecr_repository.nginx.name
 }

--- a/envs/prod/app/recordable/ecr.tf
+++ b/envs/prod/app/recordable/ecr.tf
@@ -3,3 +3,9 @@ module "nginx" {
 
   name = "infra-prod-recordable-nginx"
 }
+
+module "php" {
+  source = "../../../../modules/ecr"
+
+  name = "infra-prod-recordable-php"
+}

--- a/envs/prod/app/recordable/locals.tf
+++ b/envs/prod/app/recordable/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  service_name = "recordable"
+}

--- a/envs/prod/app/recordable/shared_locals.tf
+++ b/envs/prod/app/recordable/shared_locals.tf
@@ -1,0 +1,1 @@
+../../shared_locals.tf

--- a/envs/prod/shared_locals.tf
+++ b/envs/prod/shared_locals.tf
@@ -1,0 +1,5 @@
+locals {
+  name_prefix = "${local.system_name}-${local.env_name}"
+  system_name = "infra"
+  env_name = "prod"
+}

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,28 @@
+resource "aws_ecr_repository" "this" {
+  name = var.name
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  policy = jsonencode(
+    {
+      "rules" : [
+        {
+          "rulePriority" : 1,
+          "description" : "Hold only ${var.holding_count} images, expire all others",
+          "selection" : {
+            "tagStatus" : "any",
+            "countType" : "imageCountMoreThan", "countNumber" : var.holding_count
+          },
+          "action" : {
+            "type" : "expire"
+          }
+        }
+      ]
+    }
+  )
+  repository = aws_ecr_repository.this.name
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,8 @@
+variable "name" {
+  type = string
+}
+
+variable "holding_count" {
+  type    = number
+  default = 10
+}


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
phpのECRを追加
nginx、phpのECRをmoduleを通して呼び出す

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
AWS Fargate で Docker のコンテナを動かすためには、事前にその Docker イメージをコンテナレジストリに登録しておく必要があるため。今回はphpを実施

## やったこと
・やったことを簡単にまとめる
phpのECRを追加

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと

## 今後の変更計画
モジュールを呼び出す書き方
````
module "モジュールに付ける名前" { 
	source = "モジュールのパス"
	モジュール内で宣言している変数 = 変数の値(デフォルト値が設定されている変数は省略OK)
}
````

Terraform で作成済みの AWS リソースを、後からモジュール化するような 場合の対応方法
```
terraform state mv 移動元のリソース名 移動先のリソース名
```
移動元のリソースがあるdirへ移動してこのコマンドを追加
aws_ecr_repository.nginx とaws_ecr_lifecycle_policy.nginxを移動させた。

AWS 側に存在する ECR は、モジュールを使った ECR のコードで管理できるので
モジュールを使っていない ECR のコードを削除

Local Values：繰り返し登場する値を、一箇所で管理できる


## 備考
・その他伝えたいこと