### PR TITLE
CICDのIAM Userを追加

### DIFF
--- a/envs/prod/cicd/app_recordable/.terraform.lock.hcl
+++ b/envs/prod/cicd/app_recordable/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.42.0"
+  constraints = "3.42.0"
+  hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
+  ]
+}

--- a/envs/prod/cicd/app_recordable/backend.tf
+++ b/envs/prod/cicd/app_recordable/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "recordable-tfstate"
+    key    = "infra/prod/cicd/app_recordable_v1.0.5.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/envs/prod/cicd/app_recordable/iam.tf
+++ b/envs/prod/cicd/app_recordable/iam.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_user" "github" {
+  name = "${local.name_prefix}-${local.service_name}-github"
+
+  tags = {
+    Name = "${local.name_prefix}-${local.service_name}-github"
+  }
+}

--- a/envs/prod/cicd/app_recordable/locals.tf
+++ b/envs/prod/cicd/app_recordable/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  service_name = "recordable"
+}

--- a/envs/prod/cicd/app_recordable/provider.tf
+++ b/envs/prod/cicd/app_recordable/provider.tf
@@ -1,0 +1,1 @@
+../../provider.tf

--- a/envs/prod/cicd/app_recordable/shared_locals.tf
+++ b/envs/prod/cicd/app_recordable/shared_locals.tf
@@ -1,0 +1,1 @@
+../../shared_locals.tf

--- a/envs/prod/shared_locals.tf
+++ b/envs/prod/shared_locals.tf
@@ -1,5 +1,5 @@
 locals {
   name_prefix = "${local.system_name}-${local.env_name}"
   system_name = "infra"
-  env_name = "prod"
+  env_name    = "prod"
 }


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
CICDのIAM Userを追加

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
ソースコードリポジトリのGithub actionsを使えるようにするため。

## やったこと
・やったことを簡単にまとめる
cicd用のdirを作成してIAMユーザーを追加

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
`on`

ワークフロー処理を始めるきっかけ

Feature/branchを追加しているのは、一時検証用に追加



`jobs`

ワークフローが持つ役割みたいなもの

ジョブ名は、GitHub の Actions 実行結果画面で表示される

`steps`をつかってジョブ内で実行する処理をひとつずつ書いていく流れ



`runs-on`

ワークフローが実行される環境の OS やバージョンなどを指定



`github.ref`

コンテキストと呼ばれるもので、「refs/heads/ブランチ名」という形式で値が入っている

コミットがプッシュされたブランチ (プルリクエストがマー ジされたブランチ) が main ブランチであるときのみ、このステップが処理される（ようにしている）



`uses`

使用するアクション名を決める。github actions用に用意されている



アクセスキーとシークレットアクセスキーを発行

```
aws iam create-access-key --user-name infra-prod-recordable-github
```

Actionsのsecret keyを追加 （setting→secret）
```
PROD_AWS_ACCESS_KEY_ID
```
```
PROD_AWS_SECRET_ACCESS_KEY
```


## 今後の変更計画



## 備考
・その他伝えたいこと