### PR TITLE
VPC環境の作成

### DIFF
--- a/envs/prod/network/main/backend.tf
+++ b/envs/prod/network/main/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "recordable-tfstate"
+    key    = "infra/prod/network/main_v.1.0.5.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/envs/prod/network/main/provider.tf
+++ b/envs/prod/network/main/provider.tf
@@ -1,0 +1,1 @@
+../../provider.tf

--- a/envs/prod/network/main/shared_locals.tf
+++ b/envs/prod/network/main/shared_locals.tf
@@ -1,0 +1,1 @@
+../../shared_locals.tf

--- a/envs/prod/network/main/variables.tf
+++ b/envs/prod/network/main/variables.tf
@@ -1,0 +1,4 @@
+variable "vpc_cdir" {
+  type = string
+  default = "172.31.0.0/16"
+}

--- a/envs/prod/network/main/variables.tf
+++ b/envs/prod/network/main/variables.tf
@@ -1,4 +1,4 @@
 variable "vpc_cdir" {
-  type = string
+  type    = string
   default = "172.31.0.0/16"
 }

--- a/envs/prod/network/main/vpc.tf
+++ b/envs/prod/network/main/vpc.tf
@@ -1,0 +1,9 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${local.name_prefix}-main"
+  }
+}


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
VPC環境の作成

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
AWSアカウント専用の仮想ネットワークを構築するため。

## やったこと
・やったことを簡単にまとめる
VPC環境dirの作成
専用ファイルの作成

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
VPC：AWSアカウント専用の仮想ネットワーク
IPv4 アドレスの範囲をClassless Inter Domain Routing（CIDR）ブロック形式で指定する必要がある。
https://docs.aws.amazon.com/ja_jp/vpc/latest/userguide/VPC_Subnets.html

プライベートホストゾーン
Amazon VPC サービスで作成する 1 つ以上の VPC 内のドメインとそのサブドメインへの DNS クエリに対し、Amazon Route 53 がどのように応答するかに関する情報を保持するコンテナ
https://docs.aws.amazon.com/ja_jp/Route53/latest/DeveloperGuide/hosted-zones-private.html

## 今後の変更計画



## 備考
・その他伝えたいこと