### PR TITLE
internet gatewayの追加

### DIFF
--- a/envs/prod/network/main/.terraform.lock.hcl
+++ b/envs/prod/network/main/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.42.0"
+  constraints = "3.42.0"
+  hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
+  ]
+}

--- a/envs/prod/network/main/data.tf
+++ b/envs/prod/network/main/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/envs/prod/network/main/eip.tf
+++ b/envs/prod/network/main/eip.tf
@@ -1,0 +1,9 @@
+resource "aws_eip" "nat_gateway" {
+  for_each = var.enable_nat_gateway ? local.nat_gateway_azs : {}
+
+  vpc = true
+
+  tags = {
+    Name = "${aws_vpc.this.tags.Name}-nat-gateway-${each.key}"
+  }
+}

--- a/envs/prod/network/main/internet_gateway.tf
+++ b/envs/prod/network/main/internet_gateway.tf
@@ -1,0 +1,7 @@
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = aws_vpc.this.tags.Name
+  }
+}

--- a/envs/prod/network/main/locals.tf
+++ b/envs/prod/network/main/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  nat_gateway_azs = var.single_nat_gateway ? { keys(var.azs)[0] = values(var.azs)[0] } : var.azs
+}

--- a/envs/prod/network/main/nat_gateway.tf
+++ b/envs/prod/network/main/nat_gateway.tf
@@ -1,0 +1,10 @@
+resource "aws_nat_gateway" "this" {
+  for_each = var.enable_nat_gateway ? local.nat_gateway_azs : {}
+
+  allocation_id = aws_eip.nat_gateway[each.key].id
+  subnet_id     = aws_subnet.public[each.key].id
+
+  tags = {
+    name = "${aws_vpc.this.tags.Name}-${each.key}"
+  }
+}

--- a/envs/prod/network/main/route_table.tf
+++ b/envs/prod/network/main/route_table.tf
@@ -18,3 +18,27 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.public.id
   subnet_id      = aws_subnet.public[each.key].id
 }
+
+resource "aws_route_table" "private" {
+  for_each = var.azs
+
+  vpc_id = aws_vpc_this.id
+
+  tags = {
+    Name = "${aws_vpc.this.tags.Name}-private-${each.key}"
+  }
+}
+
+resource "aws_route" "nat_gateway_private" {
+  for_each               = var.enable_nat_gateway ? var.azs : {}
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_ant_gateway.this[var.single_nat_gateway ? keys(var.azs)[0] : each.key].id
+  route_table_id         = aws_route_table.private[each.key].id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = var.azs
+
+  route_table_id = aws_route_table.private[each.key].id
+  subnet_id      = aws_subnet.private[each.key].id
+}

--- a/envs/prod/network/main/route_table.tf
+++ b/envs/prod/network/main/route_table.tf
@@ -32,7 +32,7 @@ resource "aws_route_table" "private" {
 resource "aws_route" "nat_gateway_private" {
   for_each               = var.enable_nat_gateway ? var.azs : {}
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_ant_gateway.this[var.single_nat_gateway ? keys(var.azs)[0] : each.key].id
+  nat_gateway_id         = aws_nat_gateway.this[var.single_nat_gateway ? keys(var.azs)[0] : each.key].id
   route_table_id         = aws_route_table.private[each.key].id
 }
 

--- a/envs/prod/network/main/route_table.tf
+++ b/envs/prod/network/main/route_table.tf
@@ -1,0 +1,20 @@
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${aws_vpc.this.tags_Name}-public"
+  }
+}
+
+resource "aws_route" "internet_gateway_public" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+  route_table_id         = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = var.azs
+
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public[each.key].id
+}

--- a/envs/prod/network/main/route_table.tf
+++ b/envs/prod/network/main/route_table.tf
@@ -2,7 +2,7 @@ resource "aws_route_table" "public" {
   vpc_id = aws_vpc.this.id
 
   tags = {
-    Name = "${aws_vpc.this.tags_Name}-public"
+    Name = "${aws_vpc.this.tags.Name}-public"
   }
 }
 
@@ -22,7 +22,7 @@ resource "aws_route_table_association" "public" {
 resource "aws_route_table" "private" {
   for_each = var.azs
 
-  vpc_id = aws_vpc_this.id
+  vpc_id = aws_vpc.this.id
 
   tags = {
     Name = "${aws_vpc.this.tags.Name}-private-${each.key}"

--- a/envs/prod/network/main/security_group.tf
+++ b/envs/prod/network/main/security_group.tf
@@ -1,0 +1,52 @@
+resource "aws_security_group" "web" {
+  name   = "${aws_vpc.this.tags.Name}-web"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${aws_vpc.this.tags.Name}-web"
+  }
+}
+
+resource "aws_security_group" "vpc" {
+  name   = "${aws_vpc.this.tags.Name}-vpc"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${aws_vpc.this.tags.Name}-vpc"
+  }
+}

--- a/envs/prod/network/main/subnet.tf
+++ b/envs/prod/network/main/subnet.tf
@@ -1,0 +1,25 @@
+resource "aws_subnet" "public" {
+  for_each = var.azs
+
+  availability_zone = "${data.aws_region.current.name}${each.key}"
+  cidr_block = each.value.public_cidr
+  map_public_ip_on_launch = true
+  vpc_id = aws_vpc.this.id 
+
+  tags = {
+    Name = "${aws_vpc.this.tags.Name}-public-${each.key}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  for_each = var.azs
+
+  availability_zone = "${data.aes_region.current.name}${each.key}"
+  cidr_block = each.value.private_cidr
+  map_public_ip_on_launch = false
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${aws_vpc.this.tags.Name}-public-${each.key}"
+  }
+}

--- a/envs/prod/network/main/subnet.tf
+++ b/envs/prod/network/main/subnet.tf
@@ -14,12 +14,12 @@ resource "aws_subnet" "public" {
 resource "aws_subnet" "private" {
   for_each = var.azs
 
-  availability_zone = "${data.aes_region.current.name}${each.key}"
+  availability_zone = "${data.aws_region.current.name}${each.key}"
   cidr_block = each.value.private_cidr
   map_public_ip_on_launch = false
   vpc_id = aws_vpc.this.id
 
   tags = {
-    Name = "${aws_vpc.this.tags.Name}-public-${each.key}"
+    Name = "${aws_vpc.this.tags.Name}-private-${each.key}"
   }
 }

--- a/envs/prod/network/main/subnet.tf
+++ b/envs/prod/network/main/subnet.tf
@@ -1,10 +1,10 @@
 resource "aws_subnet" "public" {
   for_each = var.azs
 
-  availability_zone = "${data.aws_region.current.name}${each.key}"
-  cidr_block = each.value.public_cidr
+  availability_zone       = "${data.aws_region.current.name}${each.key}"
+  cidr_block              = each.value.public_cidr
   map_public_ip_on_launch = true
-  vpc_id = aws_vpc.this.id 
+  vpc_id                  = aws_vpc.this.id
 
   tags = {
     Name = "${aws_vpc.this.tags.Name}-public-${each.key}"
@@ -14,10 +14,10 @@ resource "aws_subnet" "public" {
 resource "aws_subnet" "private" {
   for_each = var.azs
 
-  availability_zone = "${data.aws_region.current.name}${each.key}"
-  cidr_block = each.value.private_cidr
+  availability_zone       = "${data.aws_region.current.name}${each.key}"
+  cidr_block              = each.value.private_cidr
   map_public_ip_on_launch = false
-  vpc_id = aws_vpc.this.id
+  vpc_id                  = aws_vpc.this.id
 
   tags = {
     Name = "${aws_vpc.this.tags.Name}-private-${each.key}"

--- a/envs/prod/network/main/variables.tf
+++ b/envs/prod/network/main/variables.tf
@@ -22,11 +22,11 @@ variable "azs" {
 }
 
 variable "enable_nat_gateway" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "single_nat_gateway" {
-  type = bool
+  type    = bool
   default = true
 }

--- a/envs/prod/network/main/variables.tf
+++ b/envs/prod/network/main/variables.tf
@@ -20,3 +20,13 @@ variable "azs" {
     }
   }
 }
+
+variable "enable_nat_gateway" {
+  type = bool
+  default = true
+}
+
+variable "single_nat_gateway" {
+  type = bool
+  default = true
+}

--- a/envs/prod/network/main/variables.tf
+++ b/envs/prod/network/main/variables.tf
@@ -2,3 +2,21 @@ variable "vpc_cdir" {
   type    = string
   default = "172.31.0.0/16"
 }
+
+variable "azs" {
+  type = map(object({
+    public_cidr  = string
+    private_cidr = string
+  }))
+
+  default = {
+    a = {
+      public_cidr  = "172.31.0.0/20"
+      private_cidr = "172.31.48.0/20"
+    },
+    c = {
+      public_cidr  = "172.31.16.0/20"
+      private_cidr = "172.31.64.0/20"
+    }
+  }
+}

--- a/envs/prod/network/main/variables.tf
+++ b/envs/prod/network/main/variables.tf
@@ -1,4 +1,4 @@
-variable "vpc_cdir" {
+variable "vpc_cidr" {
   type    = string
   default = "172.31.0.0/16"
 }


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
internet gateway、これらに関連する機能の設定を追加

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
Fargateを動かすためのネットワーク、VPC（Virtural Private Cloud）を作成するため。

## やったこと
・やったことを簡単にまとめる
Availability zoneのpublic/private subnetを追加
データソースを追加
subnetを追加
private subnetを追加
public subnet用route tableの作成
natgatewayの変数を指定
Elastic IPの作成
nat gatewayのlocal変数を追加
nat_gatewayの作成
private subnet用route tableの作成
セキュリティグループの作成
 nat_gatewayの作成準備完了
※commit履歴を参照

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
Variable "azs"(availavility zonesのazs)
デフォルトでは ap-northeast-1a と ap-northeast-1c のふたつのを使用
※aとcは上記のAvailability zoneのイニシャル（ap-northeast-1dは使わない）
map型でリソースを作成

データソース aws_region を使うことで、リージョン名を取得可能になる
subnet作成時に使用する

----------

**サブネット：ネットワーク内のネットワーク**
機器やアドレスの数が多い大きなネットワークを、管理しやすいよう小さく分割したネットワーク
TCP/IPネットワークで一つの組織に割り当てられた大きなアドレスブロックを、組織内で管理しやすい大きさに分割したもの
https://ex-ture.com/blog/2021/07/14/publicsubnet-vs-plivatesubnet/

TCP/IP：ネットワークごしの通信規約
https://www.infraexpert.com/study/tcpip.html
（チャートあり）
1.ブラウザがリクエストメッセージを作成
2.OSのTCP/IP処理ソフトがトランスポート層と呼ばれるところにデータを渡す
3.トランスポート層のTCPというプロトコルでTCPヘッダが付けられる（データの先頭にそういうデータがくっつく）
4.ネットワーク層というところにデータが送られ、ここでIPヘッダ（行き先などのデータ）がくっつく
5.MACヘッダなどのヘッダ情報がさらにくっつき、LANアダプタからデータが送られる

---------

**each.key**
each.key には、for_each に指定した map 型のキーが入る。

availability_zone に`"${data.aws_region.current.name}${each.key}"`と指定。for_each による繰り返し処理で、availability_zone の値は 1 回目が "ap-northeast-1a"、 2 回目は "ap-northeast-1c"になる。

-------------

**map_public_ip_on_launch**

trueにするとサブネット内のリソースにパブリック IP アドレスが自動割り当てされるようになっている。

------------

**aws_route_table**
パブリックサブネットから、単一のインターネットゲートウェイにルーティングする
パブリックサブネットでは共通のルートテーブルひとつを使用
パブリックサブネット用のルートテーブルについては、ひとつだけ 作成

-------------

**aws_route**
ルートテーブルに登録する、ひとつひとつのルートを作成
インターネットゲートウェイへのルートを作成したい場合には、引数 gateway_id にインターネットゲートウェイ の id を指定
引数 route_table_id には、このルートを登録するルートテーブルの id を指定

-------------

**enable_nat_gateway**
NAT ゲートウェイが必要となるのは、プライベートサブネット内のFargate が起動にあ たって ECR からイメージをプルするとき
他のリソースは維持しつつ柔軟に NAT ゲートウェイを削除したり再作成できるよう、変数を用意
（NAT ゲートウェイは東京リージョンでは 1 時間あたり、0.062USD）

Terraform のコードを apply するときに、以下のように-var オプションを付けて実行すれば、NAT ゲートウェイは作成されずに済む（defaultはtrue）
````
terraform apply -var='enable_nat_gateway=false'
````

-------------------

**single_nat_gateway**
single_nat_gateway が true の場合は、NAT ゲートウェイをひとつ作成
本来であれば、ap-northeast-1a と ap-northeast-1c 用にひとつずつ作るべきだが、コスト面を考慮して一つだけにする

-------------------

**Elastic IP** の作成
NAT ゲートウェイに固定のパブリック IP アドレスを付与するため、Elastic IP を作成

------------

**eip.tf**
var.enable_nat_gateway の値 に応じて、Elastic IP を作成するかしないかを制御（三項演算子がつかえる）

var.enable_nat_gateway が true のときは、local.nat_gateway_azs 内に入って いるアベイラビリティゾーン情報の数だけ Elastic IP が作成されて、falseでは何も作成されないので空になる


https://www.terraform.io/docs/language/functions/keys.html
https://www.terraform.io/docs/language/functions/values.html

------------

**allocation_id**
allocation_id にNAT ゲートウェイに紐付ける Elastic IP の id を指定

----------

**subnet_id**
subnet_id にNAT ゲートウェイを紐付けるサブネットの id を指定。
NAT ゲートウェイはパブリックサブネットに紐付け

----------

**aws_route_table**
プライベートサブネット用のルートテーブルを複数作成。NAT ゲートウェイの数が 0 個や 1 個でもルートテーブルは複数作成

----------

**aws_route**
プライベートサブネット用の各ルートテーブルに登録する、NAT ゲートウェイのルートを複数作成。
var.enable_nat_gateway が false の場合は、ルートを作成しない。（NAT ゲートウェイが存在しない。）
var.enable_nat_gateway が true の場合、ルートを複数作成。

「aws_nat_gateway.this[キー].id」となっており、ひとつから複数存在する可能性のある NAT ゲートウェイのうち、キーに該当する NAT ゲートウェイの id を参照。
キー：「var.single_nat_gateway ? keys(var.azs)[0] : each.key」
var.single_nat_gateway が true のときは、「keys(var.azs)[0]」

「keys(var.azs)」は、variables.tfで指定している「["a", "c"]」

```
variable "azs" {
  type = map(object({
    public_cidr  = string
    private_cidr = string
  }))

  default = {
    a = {
      public_cidr  = "172.31.0.0/20"
      private_cidr = "172.31.48.0/20"
    },
    c = {
      public_cidr  = "172.31.16.0/20"
      private_cidr = "172.31.64.0/20"
    }
  }
}
```

「keys(var.azs)[0]」は、「"a"」になる。つ まり、for_each による繰り返し処理が何回あっても、nat_gateway_id には常にキー が「"a"」である NAT ゲートウェイの id が指定される。

var.single_nat_gateway が false のときは、each.key。
each.key は、for_each による繰り返し処理に応じて最初は「"a"」、次に「"c"」。
こう書くことでNAT ゲートウェイがひとつであれば、そこに向いたルートを複数作成。
 NAT ゲートウェイが複数であれば、それぞれに向いたルートを複数作成するようにできる。

-------------

**aws_route_table_association**
プライベート用ルートテーブルとプライベートサブネットの紐付けを実施

----------

**security_group.tf**
aws_security_group.web と aws_security_group.vpc のふたつのセキュリ ティグループを作成
・aws_security_group.web：VPC 外部からの HTTP や HTTPS 通信を許可するセ キュリティグループとして作成
・ aws_security_group.vpc：PC 内 部リソース同士のあらゆる通信を許可するセキュリティグループとして作成

----------

**ingress**
セキュリティグループが付けられたリソースに対するインバウンド通信の許可設定を追加

**from_port / to_port**
許可するポート番号の範囲
aws_security_group.web の ingress では、80 番ポート (HTTP) と 443 番ポート (HTTPS) を許可。aws_security_group.vpc の ingress では、0 番ポートを 指定していますが、これは全てのポート番号を許可するのと同じ。

**protocol**
許可するプロトコル（通信のルール）を指定。aws_security_group.vpc の ingress では、「"-1"」を 指定していますが、これは全てのプロトコルを許可することになる。

**egress**
セキュリティグループが付けられたリソースからのアウトバウンド通信の許可設定を記述する。

**self**
true の時、このセキュリティグループ自身が付けられたリソースからの通信が許可される。

新しくファイルを作成したので、initializationが必要となる。
```
terraform init
```

費用を考え、NAT ゲートウェイを一旦作成しないでおきたいので下記のコマンドを使用した。
```
terraform apply -var='enable_nat_gateway=false'
```

**terraformソースを間違えても、書き直したあとに`terraform init`を行えば問題なし。**

## 今後の変更計画

## 備考
・その他伝えたいこと