### PR TITLE
DNSの設定とACMの発行

### DIFF
--- a/envs/prod/routing/recordable_jp/.terraform.lock.hcl
+++ b/envs/prod/routing/recordable_jp/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.42.0"
+  constraints = "3.42.0"
+  hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
+  ]
+}

--- a/envs/prod/routing/recordable_jp/acm.tf
+++ b/envs/prod/routing/recordable_jp/acm.tf
@@ -1,0 +1,13 @@
+resource "aws_acm_certificate" "root" {
+  domain_name = data.aws_route53_zone.this.name
+
+  validation_method = "DNS"
+
+  tags = {
+    Name = "${local.name_prefix}-recordable-jp"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/envs/prod/routing/recordable_jp/acm.tf
+++ b/envs/prod/routing/recordable_jp/acm.tf
@@ -11,3 +11,7 @@ resource "aws_acm_certificate" "root" {
     create_before_destroy = true
   }
 }
+
+resource "aws_acm_certificate_validation" "root" {
+  certificate_arn = aws_acm_certificate.root.arn
+}

--- a/envs/prod/routing/recordable_jp/backend.tf
+++ b/envs/prod/routing/recordable_jp/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "recordable-tfstate"
+    key    = "infra/prod/routing/recordable_jp_v1.0.5.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/envs/prod/routing/recordable_jp/provider.tf
+++ b/envs/prod/routing/recordable_jp/provider.tf
@@ -1,0 +1,1 @@
+../../provider.tf

--- a/envs/prod/routing/recordable_jp/route53.tf
+++ b/envs/prod/routing/recordable_jp/route53.tf
@@ -1,0 +1,3 @@
+data "aws_route53_zone" "this" {
+  name = "recordable.jp"
+}

--- a/envs/prod/routing/recordable_jp/route53.tf
+++ b/envs/prod/routing/recordable_jp/route53.tf
@@ -1,3 +1,19 @@
 data "aws_route53_zone" "this" {
   name = "recordable.jp"
 }
+
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.root.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  ttl     = 60
+  type    = each.value.type
+  zone_id = data.aws_route53_zone.this.id
+}

--- a/envs/prod/routing/recordable_jp/shared_locals.tf
+++ b/envs/prod/routing/recordable_jp/shared_locals.tf
@@ -1,0 +1,1 @@
+../../shared_locals.tf


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
DNSの設定とACMの発行

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
独自ドメインを使えるようにするのと、ACMで  SSL（Secure Sockets Layer）の対応を行うため。

**SSL**
インターネット上でやりとりされるデータの「盗聴」「なりすまし」を防止するための暗号化プロトコル

## やったこと
・やったことを簡単にまとめる
routing dirを作成してs3を定義、シンボリックリンクを追加
route53.tfの追加
ACMで証明書発行
route53にdns validationを追加
ACMの発行成功をAWS consoleで確認

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
`nslookup -type=NS recordable.jp`
https://dev.classmethod.jp/articles/route53-domain-onamae/

--------

route53.tf
name が一致するホストゾーンをデータソースとして参照する。
→ドメイン名を追加

---------

ホストゾーン
ドメインとそのサブドメインのトラフィックのルーティングする方法についての情報を保持するコンテナ的な認識でOK

-----------

**domain_name**
発行する証明書のドメイン名にする。data.aws_route53_zone.this.name とすれば、Route53に登録しているドメイン名を指定することができる。

----------

**validation_method**
ドメインの所有権の検証を、どういった方法でおこなうかを指定。DNSで検証。

-----------

**lifecycle / create_before_destroy**
Terraform はデフォルトでは**リソースを再作成するときに、古いリソースを削除してから新しいリソースを作成**する。
lifecycleブロックの create_before_destroy を true にすると、新しいリソースを作成してから古いリソースを削除できる。
証明書については、ロードバランサーのリスナーなどで使用中の場合を考慮すると、
create_before_destroy を true にしておくことが推奨されている。

---------

dns validation
terraformのサンプル参照
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation

-------

**aws_acm_certificate_validation**
arnはamazon resource name。`terraform apply`すると DNS 検証が完了するまで待ち、検証が完了すると apply が完了する。







## 今後の変更計画


## 備考
・その他伝えたいこと