### PR TITLE
ALBアクセスログのためのS3を作成

### DIFF
--- a/envs/prod/log/alb/.terraform.lock.hcl
+++ b/envs/prod/log/alb/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.42.0"
+  constraints = "3.42.0"
+  hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
+  ]
+}

--- a/envs/prod/log/alb/backend.tf
+++ b/envs/prod/log/alb/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = ""
+    key = "infra/prod/log/alb_v1.0.5.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/envs/prod/log/alb/backend.tf
+++ b/envs/prod/log/alb/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket = ""
-    key = "infra/prod/log/alb_v1.0.5.tfstate"
+    bucket = "recordable-tfstate"
+    key    = "infra/prod/log/alb_v1.0.5.tfstate"
     region = "ap-northeast-1"
   }
 }

--- a/envs/prod/log/alb/data.tf
+++ b/envs/prod/log/alb/data.tf
@@ -1,0 +1,1 @@
+data "aws_elb_service_account" "current" {}

--- a/envs/prod/log/alb/outputs.tf
+++ b/envs/prod/log/alb/outputs.tf
@@ -1,0 +1,3 @@
+output "s3_bucket_this_id" {
+  value = aws_s3_bucket.this.id
+}

--- a/envs/prod/log/alb/provider.tf
+++ b/envs/prod/log/alb/provider.tf
@@ -1,0 +1,1 @@
+../../provider.tf

--- a/envs/prod/log/alb/s3.tf
+++ b/envs/prod/log/alb/s3.tf
@@ -1,0 +1,63 @@
+resource "aws_s3_bucket" "this" {
+  bucket = "soregashi27-${local.name_prefix}-alb-log"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = {
+    Name = "soregashi27-${local.name_prefix}-alb-log"
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = "90"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : "arn:aws:iam::${data.aws_elb_service_account.current.id}:root"
+          },
+          "Action" : "s3:PutObject",
+          "Resource" : "arn:aws:s3:::${aws_s3_bucket.this.id}/*"
+        },
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "delivery.logs.amazonaws.com"
+          },
+          "Action" : "s3:PutObject",
+          "Resource" : "arn:aws:s3:::${aws_s3_bucket.this.id}/*",
+          "Condition" : {
+            "StringEquals" : {
+              "s3:x-amz-acl" : "bucket-owner-full-control"
+            }
+          }
+        },
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "delivery.logs.amazonaws.com"
+          },
+          "Action" : "s3:GetBucketAcl",
+          "Resource" : "arn:aws:s3:::${aws_s3_bucket.this.id}"
+        }
+      ]
+    }
+  )
+}

--- a/envs/prod/log/alb/shared_locals.tf
+++ b/envs/prod/log/alb/shared_locals.tf
@@ -1,0 +1,1 @@
+../../shared_locals.tf


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
ALBアクセスログのためのS3を作成
ALBの作成は次回

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
Fargateの前段に置くALBは、アクセスログをS3に保存する機能があるので活用するため

## やったこと
・やったことを簡単にまとめる
log/albのs3bucketを作成
albのbackendを設定
バケットポリシーを追加
data.tfを追加
output valuesの作成

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
`backend.tf`について

状態 (state) の読み込み方法や、適用 (apply) などの操作の実行方法を決めるもの
https://vividcode.hatenablog.com/entry/terraform/remote-backend

S3のバケット名での注意点
世界中で他と被らないユニークな名前にする必要がある
今回はgithubのアカウント名（ハイフンなし）にした。

参考：
・【小ネタ】TerraformでALBアクセスログに暗号化したS3バケットを指定すると失敗して困った話
sse_algorithmについて
https://dev.classmethod.jp/articles/alb-log-s3-default-encryption/

・AWSセキュリティ編～AES256について～
https://recipe.kc-cloud.jp/archives/6029

--------

**server_side_encryption_configuration**
S3 の暗号化の設定。上記のコードでは、S3 が管理するキーにより暗号化が行われる。

----------

**lifecycle_rule**
S3 バケット内のオブジェクトの保持期間ルール。

----------

**enabled**
true にしたら、lifecycle_rule が有効になる。

----------

**expiration**
S3 のオブジェクト (Application Load Balancerのアクセスログファイル) を 90 日保持するように指定。

----------

バケットポリシー
ALB がS3バケットにログを書き込みできるようにするために、S3バ ケット側で書き込みを許可しておく
https://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/application/load-balancer-access-logs.html

**ALB vs ELB**
・ALB：Webサービスにかかる負荷を分散し、安定性や高可用性を向上させる
・ELB：元々のAWSにおけるload balancing service
今ではCLBやNLBというload balancing serviceがでてきたことから、ELBはload balancing serviceの総称的な感じになった。

参考：【ALBとELBの違い】初心者でもわかる簡単 AWS 用語解説
https://www.wafcharm.com/blog/difference-between-alb-and-elb/

参考：AWS公式ドキュメント
https://aws.amazon.com/jp/elasticloadbalancing/

--------

**aws_elb_service_account**
データソースのaws_elb_service_account を使って、AWS が ELB(Elastic Load Balancer) の管理をおこなっている AWSがELBの管理を行っているAWS アカウント ID を参照できる。今回つかっている東京regionのアカウントID は「582318560864」。

データソース aws_elb_service_account は引数 region を持っている。

region ID を指定したかによって、アカウント ID(属性 id の値) が変わる。引数 region を省略した場合、provider ブロックのregionの値、 "ap-northeast-1"がつかわれる。データソース aws_elb_service_account を使えばAWSのアカウントIDを書かなくて済む。

---------

**Output Values**
Terraformでは、ある tfstate において output として宣言された値を、terraform_remote_state というデータソースを使うことで、別のディレクトリから参照することができる。後ほど`/prod/routing/recordable_jp` dirでALBを作成するとき、`/prod/log/alb` dirで作成した S3 バケットの ID が必要になる。

ここでOutput Valuesとして宣言しとけば使える。
Output Values は、outputs.tf というファイル名の中で宣言することが一般的。
「リソース種類_リソース名_属性名」での命名。


## 今後の変更計画
ALBの作成

## 備考
・その他伝えたいこと

**エラーについて**
・詰まったエラー
```
Initializing the backend...
╷
│ Error: Backend configuration changed
│ 
│ A change in the backend configuration has been detected, which may require migrating existing state.
│ 
│ If you wish to attempt automatic migration of the state, use "terraform init -migrate-state".
│ If you wish to store the current configuration with no changes to the state, use "terraform init -reconfigure".
╵

> terraform init -migrate-state

Initializing the backend...
Backend configuration changed!

Terraform has detected that the configuration specified for the backend
has changed. Terraform will now check for existing state in the backends.


╷
│ Error: Error loading state:
│     InvalidParameter: 1 validation error(s) found.
│ - minimum field size of 1, GetObjectInput.Bucket.
│ 
│ 
│ Terraform failed to load the default state from the "s3" backend.
│ State migration cannot occur unless the state can be loaded. Backend
│ modification and state migration has been aborted. The state in both the
│ source and the destination remain unmodified. Please resolve the
│ above error and try again.
│ 
│ 
╵
```

`.terraform` dirを削除して、再度`terraform init`をして解決。

シンボリックリンクを作成した後なのでこのような形で対処できた。
※いくつかresourceがあるなかでこのように対処する場合は注意したい



