### PR TITLE
s3_bucket_idを一意の言葉（recordable）に変更

### DIFF
--- a/envs/prod/log/alb/s3.tf
+++ b/envs/prod/log/alb/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "this" {
-  bucket = "soregashi27-${local.name_prefix}-alb-log"
+  bucket = "recordable-${local.name_prefix}-alb-log"
 
   server_side_encryption_configuration {
     rule {
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "this" {
   }
 
   tags = {
-    Name = "soregashi27-${local.name_prefix}-alb-log"
+    Name = "recordable-${local.name_prefix}-alb-log"
   }
 
   lifecycle_rule {


### PR DESCRIPTION
元々違う言葉にしていたが、今後の開発をふまえて"recordable"と変更

`s3_bucket_this_id = "recordable-infra-prod-alb-log"`

以下省略。