### PR TITLE
outputsファイルの追加

### DIFF
--- a/envs/prod/network/main/outputs.tf
+++ b/envs/prod/network/main/outputs.tf
@@ -1,0 +1,11 @@
+output "security_group_web_id" {
+  value = aws_security_group.web.id
+}
+
+output "security_group_vpc_id" {
+  value = aws_security_group.vpc.id
+}
+
+output "subnet_public" {
+  value = aws_subnet.public
+}


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト


## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
Application Load Balancerの作成にあたって、サブネットIDとセキュリティグループIDを管理している
`/prod/network/main` dirのtfstateからoutputして使えるようにするため。
（他のdirからterraform_remote_stateを通してtfstate上のoutputが参照できるようになる）

**ALBを作る工程に何度も失敗しているので、今回はoutputsファイルの追加時で一旦branchを切る。**

参考：【ALBとELBの違い】初心者でもわかる簡単 AWS 用語解説
https://www.wafcharm.com/blog/difference-between-alb-and-elb/

## やったこと
・やったことを簡単にまとめる
`/prod/network/main` dirに`outputs.tf`を追加

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
NAT ゲートウェイを作成しないでおきたい場合は下記で一時対応可能
`terraform apply -var='enable_nat_gateway=false'`

## 今後の変更計画
terraform_remote_stateを作成

## 備考
・その他伝えたいこと